### PR TITLE
Fix "into" typo and remove unneeded <iostream> include

### DIFF
--- a/PerlinNoise.cpp
+++ b/PerlinNoise.cpp
@@ -1,5 +1,4 @@
 #include "PerlinNoise.h"
-#include <iostream>
 #include <cmath>
 #include <random>
 #include <algorithm>
@@ -87,7 +86,7 @@ double PerlinNoise::lerp(double t, double a, double b) {
 
 double PerlinNoise::grad(int hash, double x, double y, double z) {
 	int h = hash & 15;
-	// Convert lower 4 bits of hash inot 12 gradient directions
+	// Convert lower 4 bits of hash into 12 gradient directions
 	double u = h < 8 ? x : y,
 		   v = h < 4 ? y : h == 12 || h == 14 ? x : z;
 	return ((h & 1) == 0 ? u : -u) + ((h & 2) == 0 ? v : -v);


### PR DESCRIPTION
No classes (cin, cout, cerr, clog) are used from <iostream> so I removed the include.
